### PR TITLE
fix: Remove notify_keymap_layout_group_changed from meta-backend-x11.c

### DIFF
--- a/src/backends/x11/meta-backend-x11.c
+++ b/src/backends/x11/meta-backend-x11.c
@@ -409,10 +409,6 @@ handle_host_xevent (MetaBackend *backend,
                   layout_group_changed =
                     (int) priv->keymap_layout_group != layout_group;
                   priv->keymap_layout_group = layout_group;
-
-                  if (layout_group_changed)
-                    meta_backend_notify_keymap_layout_group_changed (backend,
-                                                                     layout_group);
                 }
               break;
             default:


### PR DESCRIPTION
Explanation: https://gitlab.gnome.org/GNOME/gnome-shell/-/issues/1154#note_1065418